### PR TITLE
Update README.md with new additional AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Download the binary from Github Releases and put it in your `$PATH`.
 
 ### From the AUR
 
-Use your favorite AUR helper.
+Use your favorite AUR helper to install `trashy` or `trashy-git`. Trashy git will remain up to date with the `master` branch.
 
 ```bash
-paru -S trashy
+paru -S <trashy or trashy-git>
 ```
 
 ### Using Nix


### PR DESCRIPTION
Hi there! I've added a `-git` package for the AUR [here](https://aur.archlinux.org/packages/trashy-git). I mainly made the package because of #103 being merged solving a critical issue for me with ZSH. This PR is just a small change to the README to reflect that.

While doing that, I noticed that the tags on the latest commits are incorrect, so if possible could you please fix that up? Right now, `git describe --tags` returns `v1.0.3-46-gc95b22c` when it should probably return something starting in `v2.0.0` since that's the current release. This is because the tag associated with the latest commit hasn't been updated to the latest tag.